### PR TITLE
remove bookings on facility change

### DIFF
--- a/booking-facilities/Controllers/FacilitiesController.cs
+++ b/booking-facilities/Controllers/FacilitiesController.cs
@@ -145,6 +145,8 @@ namespace booking_facilities.Controllers
             {
                 try
                 {
+                    var bookings = _context.Booking.Where(b => b.FacilityId.Equals(facility.FacilityId) && !b.IsBlock);
+                    _context.Booking.RemoveRange(bookings);
                     _context.Update(facility);
                     await _context.SaveChangesAsync();
                 }


### PR DESCRIPTION
When an admin changes a facility to a different name, sport or venue -> all bookings will be removed. Blocks will remain on the facility.